### PR TITLE
Fix compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ PARALLEL_REQUIRE = ["ray[debug,tune]~=2.0.0"]
 PYTYPE = ["pytype==2022.7.26"] if IS_NOT_WINDOWS else []
 if IS_NOT_WINDOWS:
     # TODO(adam): use this for Windows as well once PyPI is at >=1.6.1
-    STABLE_BASELINES3 = "stable-baselines3>=1.6.0"
+    STABLE_BASELINES3 = "stable-baselines3>=1.4.0"
 else:
     STABLE_BASELINES3 = (
         "stable-baselines3@git+"


### PR DESCRIPTION
## Description

Downgrade gym and stable-baselines3 version to fix [#47](https://github.com/BASALT-2022-Karlsruhe/ka-basalt-2022/issues/47)

## Testing

Created conda env where I installed minerl, this modified version of imitation and pytorch with the required versions.
Also I had to install werkzeug==2.1 in order for minerl to properly import.